### PR TITLE
Lagt til enkel henting av stillingsannonse fra pam-ad

### DIFF
--- a/src/main/kotlin/no/nav/pam/euresstillingeksport/feedclient/AdFeedClient.kt
+++ b/src/main/kotlin/no/nav/pam/euresstillingeksport/feedclient/AdFeedClient.kt
@@ -1,0 +1,42 @@
+package no.nav.pam.euresstillingeksport.feedclient
+
+import no.nav.pam.euresstillingeksport.model.pam.Ad
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.stereotype.Service
+import org.springframework.web.client.RestClientException
+import org.springframework.web.client.RestTemplate
+
+@Service
+class AdFeedClient @Autowired constructor (
+        @Value("\${pam-ad.url}")
+        private val adApiURL : String,
+        private val restTemplate : RestTemplate) {
+    companion object {
+        private val LOG = LoggerFactory.getLogger(AdFeedClient::class.java)
+    }
+
+
+    fun getAd(uuid : String) : Ad {
+        try {
+            val response = restTemplate.getForEntity("${adApiURL}/feed?uuid=${uuid}", FeedTransport::class.java)
+            // TODO sjekk responskode og håndter feil på en grei nok måte
+            return response.body?.content.orEmpty()[0]
+        } catch (e: RestClientException) {
+            if (e.cause is HttpMessageNotReadableException) {
+                // Dette er en applikasjonsfeil som det ikke vil nytte å rekjøre, typisk pga feil i parsing av JSON
+                LOG.error("Greide ikke å lese svar fra pam-ad ved uthenting av ad {}: {}", uuid, e.message, e)
+                throw IllegalArgumentException("Greide ikke å lese respons fra pam-ad: ${e.message}", e)
+            }
+            // TODO det er mer som skal håndteres her...
+            throw e
+        } catch (e: Exception) {
+            // TODO vi må ha ordentlig feilhåndtering, og der har ikke catch all en rolle
+            LOG.error("Dette var ikke helt som forventet", e)
+            throw e
+        }
+
+    }
+}

--- a/src/main/kotlin/no/nav/pam/euresstillingeksport/feedclient/FeedTransport.kt
+++ b/src/main/kotlin/no/nav/pam/euresstillingeksport/feedclient/FeedTransport.kt
@@ -1,0 +1,16 @@
+package no.nav.pam.euresstillingeksport.feedclient
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import no.nav.pam.euresstillingeksport.model.pam.Ad
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class FeedTransport (
+    val last: Boolean,
+    val totalPages: Int,
+    val totalElements: Int,
+    val size: Int,
+    val number: Int,
+    val first: Boolean,
+    val numberOfElements: Int,
+    val content: List<Ad>
+)

--- a/src/main/kotlin/no/nav/pam/euresstillingeksport/model/pam/Ad.kt
+++ b/src/main/kotlin/no/nav/pam/euresstillingeksport/model/pam/Ad.kt
@@ -1,85 +1,91 @@
 package no.nav.pam.euresstillingeksport.model.pam
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import java.time.LocalDateTime
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class Ad(
-        private val id: Long,
-        private val uuid: String,
-        private val created: LocalDateTime,
-        private val createdBy: String?,
-        private val updated: LocalDateTime,
-        private val updatedBy: String?,
-        //private val mediaList: [],
-        //private val contactList [],
-        private val locationList: List<Location>,
-        private val properties: Map<String, String>,
-        private val title: String?,
-        private val status: String?,
-        private val privacy: String?,
-        private val source: String?,
-        private val medium: String?,
-        private val reference: String?,
-        private val published: LocalDateTime?,
-        private val expires: LocalDateTime?,
-        private val employer: Employer,
-        private val categoryList: List<Category>,
-        private val administration: Administration,
-        private val publishedByAdmin: String,
-        private val businessName: String,
-        private val firstPublished: Boolean,
-        private val deactivatedByExpiry: Boolean,
-        private val activationOnPublishingDate: Boolean
+        val id: Long,
+        val uuid: String,
+        val created: LocalDateTime,
+        val createdBy: String?,
+        val updated: LocalDateTime,
+        val updatedBy: String?,
+        //val mediaList: [],
+        //val contactList [],
+        val locationList: List<Location>,
+        val properties: Map<String, String>,
+        val title: String?,
+        val status: String?,
+        val privacy: String?,
+        val source: String?,
+        val medium: String?,
+        val reference: String?,
+        val published: LocalDateTime?,
+        val expires: LocalDateTime?,
+        val employer: Employer,
+        val categoryList: List<Category>,
+        val administration: Administration,
+        val publishedByAdmin: String?,
+        val businessName: String,
+        val firstPublished: Boolean,
+        val deactivatedByExpiry: Boolean,
+        val activationOnPublishingDate: Boolean
 )
 
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class Location(
-        private val address: String?,
-        private val postalCode: String?,
-        private val county: String?,
-        private val municipal: String?,
-        private val municipalCode: String?,
-        private val city: String?,
-        private val country: String?,
-        private val latitude: String?,
-        private val longitude: String?
+        val address: String?,
+        val postalCode: String?,
+        val county: String?,
+        val municipal: String?,
+        val municipalCode: String?,
+        val city: String?,
+        val country: String?,
+        val latitude: String?,
+        val longitude: String?
 )
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class Category(
-        private val id: Long,
-        private val code: String?,
-        private val categoryType: String?,
-        private val name: String?,
-        private val description: String?,
-        private val parentId: Long?
+        val id: Long,
+        val code: String?,
+        val categoryType: String?,
+        val name: String?,
+        val description: String?,
+        val parentId: Long?
 )
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class Administration(
-        private val id: Long,
-        private val status: String,
-        private val comments: String,
-        private val reportee: String,
-        private val remarks: List<String>,
-        private val navIdent: String
+        val id: Long,
+        val status: String,
+        val comments: String?,
+        val reportee: String?,
+        val remarks: List<String>,
+        val navIdent: String?
 )
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class Employer(
-        private val id: Long,
-        private val uuid: String,
-        private val created: String?,
-        private val createdBy: String?,
-        private val updated: String?,
-        private val updatedBy: String?,
-        // private val mediaList: [],
-        // private val contactList: [],
-        private val locationList: List<Location>,
-        private val properties: List<String>,
-
-        private val name: String?,
-        private val orgnr: String?,
-        private val status: String?,
-        private val parentOrgnr: String?,
-        private val publicName: String?,
-        private val deactivated: Boolean,
-        private val orgform: String?,
-        private val employees: Int
+        val id: Long,
+        val uuid: String,
+        val created: String?,
+        val createdBy: String?,
+        val updated: String?,
+        val updatedBy: String?,
+        // val mediaList: [],
+        // val contactList: [],
+        val locationList: List<Location>,
+        // Key er key (f.eks nace2, value er en json string)
+        val properties: Map<String, String>,
+        val name: String?,
+        val orgnr: String?,
+        val status: String?,
+        val parentOrgnr: String?,
+        val publicName: String?,
+        val deactivated: Boolean,
+        val orgform: String?,
+        val employees: Int
 )

--- a/src/main/kotlin/no/nav/pam/euresstillingeksport/rest/ApiConfiguration.kt
+++ b/src/main/kotlin/no/nav/pam/euresstillingeksport/rest/ApiConfiguration.kt
@@ -1,7 +1,11 @@
 package no.nav.pam.euresstillingeksport.rest
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.datatype.jsr310.deser.JSR310DateTimeDeserializerBase
 import com.fasterxml.jackson.module.kotlin.KotlinModule
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.web.client.RestTemplateBuilder
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
@@ -13,5 +17,10 @@ class JacksonConfiguration {
     open fun objectMapper() =
             ObjectMapper().apply {
                 registerModule(KotlinModule())
+                registerModule(JavaTimeModule())
             }
+
+    @Bean
+    open fun restTemplate(@Autowired restTemplateBuilder : RestTemplateBuilder) =
+            restTemplateBuilder.build()
 }

--- a/src/main/resources/application-dev-sbs.yml
+++ b/src/main/resources/application-dev-sbs.yml
@@ -1,0 +1,2 @@
+pam-ad:
+  url: http://pam-ad.default.svc.nais.local:80/api/v1/ads

--- a/src/main/resources/application-prod-sbs.yml
+++ b/src/main/resources/application-prod-sbs.yml
@@ -1,0 +1,2 @@
+pam-ad:
+  url: http://pam-ad.default.svc.nais.local:80/api/v1/ads

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,5 @@
+pam-ad:
+  url: https://pam-ad.nais.oera-q.local/api/v1/ads
+spring:
+  main:
+    allow-bean-definition-overriding: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,6 +12,8 @@ spring:
   metrics.web.server.auto-time-requests: true
   main:
     banner-mode: "off"
+  profiles:
+    active: ${NAIS_CLUSTER_NAME}
 server:
   error:
     whitelabel:
@@ -19,5 +21,3 @@ server:
     include-stacktrace: never
   servlet:
     context-path: /
-  profiles:
-    active: ${NAIS_CLUSTER_NAME}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,4 +18,6 @@ server:
       enabled: true
     include-stacktrace: never
   servlet:
-    context-path: /pam-eures-stilling-eksport
+    context-path: /
+  profiles:
+    active: ${NAIS_CLUSTER_NAME}

--- a/src/test/kotlin/no/nav/pam/euresstillingeksport/EuresStillingEksportApplicationTests.kt
+++ b/src/test/kotlin/no/nav/pam/euresstillingeksport/EuresStillingEksportApplicationTests.kt
@@ -9,8 +9,10 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.test.context.ActiveProfiles
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
 class EuresStillingEksportApplicationTests {
 
 	@Autowired
@@ -55,5 +57,4 @@ class EuresStillingEksportApplicationTests {
 		Assertions.assertNotNull(response.body)
 		Assertions.assertNotNull(response.body!!.details)
 	}
-
 }

--- a/src/test/kotlin/no/nav/pam/euresstillingeksport/PamAdITests.kt
+++ b/src/test/kotlin/no/nav/pam/euresstillingeksport/PamAdITests.kt
@@ -1,0 +1,72 @@
+package no.nav.pam.euresstillingeksport
+
+import no.nav.pam.euresstillingeksport.feedclient.AdFeedClient
+import no.nav.pam.euresstillingeksport.model.Converters
+import no.nav.pam.euresstillingeksport.service.GetAllResponse
+import no.nav.pam.euresstillingeksport.service.GetChangesResponse
+import no.nav.pam.euresstillingeksport.service.GetDetailsResponse
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.boot.web.client.RestTemplateBuilder
+import org.springframework.context.annotation.Bean
+import org.springframework.http.client.SimpleClientHttpRequestFactory
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.web.client.RestTemplate
+import java.security.SecureRandom
+import java.security.cert.X509Certificate
+import javax.net.ssl.*
+
+/**
+ * Dette er en integrasjonstest som går mot pam-ad i q. Denne testen vil aldri kunne kjøre på github, og skal derfor ignoreres
+ * Hvis man skal kjøre denne desten må man enten sette opp en testpipeline som deployer til q (ganske uaktuelt) eller
+ * lage en egen test som mocker pam-ad (litt mer sannsynlig - men da er det ikke en ordentlig integrasjonstest lenger)
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@Disabled("Integrasjonstest som ikke kjører på github")
+class PamAdITests {
+
+	@Autowired
+	lateinit var restTemplate: TestRestTemplate
+
+	@Autowired
+	lateinit var adClient: AdFeedClient
+
+	val root = "/input/api/jv/v0.1"
+
+	@TestConfiguration
+	class TestConfig {
+		@Bean
+		open fun restTemplate(@Autowired restTemplateBuilder: RestTemplateBuilder): RestTemplate {
+			// Vi ignorerer SSL feil når vi tester mot preprod/q
+			val trustManager: X509TrustManager = object: X509TrustManager {
+				override fun checkClientTrusted(chain: Array<out X509Certificate>?, authType: String?) {
+				}
+				override fun checkServerTrusted(chain: Array<out X509Certificate>?, authType: String?) {
+				}
+				override fun getAcceptedIssuers(): Array<X509Certificate> =
+						emptyArray()
+			}
+
+			val sslContext: SSLContext = SSLContext.getInstance("TLS")
+			sslContext.init(null, arrayOf(trustManager), SecureRandom())
+
+			HttpsURLConnection.setDefaultSSLSocketFactory(sslContext.socketFactory)
+			HttpsURLConnection.setDefaultHostnameVerifier { hostname, session -> true }
+
+			return restTemplateBuilder.build()
+		}
+	}
+
+
+	@Test
+	fun skaHenteAd() {
+		val ad = adClient.getAd("db6cc067-7f39-42f1-9866-d9ee47894ec6")
+		Assertions.assertEquals("INACTIVE", ad.status)
+	}
+}


### PR DESCRIPTION
Dette er ørlite mer enn å fjerne contextpat. Inneholder enkelt kall mot pam-ad for å hente stillingsannonse.

Koden er ikke helt i den stand den bør være når vi skal i prod: 

- det bør være bedre feilhåndtering i kall mot pam-ad
- Bør lage en wiremock versjon av kallene mot pam-ad slik at de kan kjøre på byggserver
