### PR TITLE
Filterer bort stillinger med kilde EURES

### DIFF
--- a/src/main/kotlin/no/nav/pam/euresstillingeksport/model/Ad.kt
+++ b/src/main/kotlin/no/nav/pam/euresstillingeksport/model/Ad.kt
@@ -34,6 +34,7 @@ data class Ad(
         val activationOnPublishingDate: Boolean
 ) {
     fun erSaksbehandlet() = administration?.erSaksbehandlet() ?: false
+    fun erFraEures() = source == "EURES"
     fun erIntern() = privacy == null || privacy == "INTERNAL_NOT_SHOWN"
     fun erIkkeIntern() = erIntern().not()
 }

--- a/src/main/kotlin/no/nav/pam/euresstillingeksport/model/StillingService.kt
+++ b/src/main/kotlin/no/nav/pam/euresstillingeksport/model/StillingService.kt
@@ -34,6 +34,10 @@ class StillingService(@Autowired private val stillingRepository: StillingReposit
                     if(!it.erSaksbehandlet()) LOG.info("Avviser stillingen ${it.uuid} siden den ikke er saksbehandlet, men har status ${it.administration?.status}")
                     it.erSaksbehandlet()
                 }.filter {
+                    if(it.erFraEures()) LOG.info("Avviser stillingen ${it.uuid} siden den stammer fra EURES, source=${it.source}")
+                    !it.erFraEures()
+                }
+                .filter {
             try {
                 it.convertToPositionOpening()
                 true

--- a/src/test/kotlin/no/nav/pam/euresstillingeksport/service/StillingServiceTest.kt
+++ b/src/test/kotlin/no/nav/pam/euresstillingeksport/service/StillingServiceTest.kt
@@ -18,6 +18,7 @@ class FetchTest {
     private val mockedRepo: StillingRepository = mock<StillingRepository>(StillingRepository::class.java)
 
     private val stillingService = StillingService(mockedRepo, objectMapper)
+    
     @Test
     fun `skal håndtere at stilling ikke finnes`() {
         Mockito.`when`(mockedRepo.findStillingsannonseById(ArgumentMatchers.anyString())).thenReturn(null)
@@ -108,7 +109,25 @@ class FiltreringsTest {
         assertThat(stillingService.lagreStillinger(ads)).isEqualTo(1)
     }
 
+    @Test
+    fun `skal filtrere bort stillinger med kilde EURES`() {
 
+        val stillingMedEuresKilde = adMother.copy(source = "EURES")
+
+        val ads = listOf(stillingMedEuresKilde)
+
+        assertThat(stillingService.lagreStillinger(ads)).isEqualTo(0)
+    }
+
+    @Test
+    fun `skal filtrere akseptere stillinger med andre kilder enn EURES`() {
+
+        val stillingRegistrertAvSaksbehandler = adMother.copy(source = "ASS")
+
+        val ads = listOf(stillingRegistrertAvSaksbehandler)
+
+        assertThat(stillingService.lagreStillinger(ads)).isEqualTo(1)
+    }
 }
 
 private val stillingsannonseMetadataMother = StillingsannonseMetadata(


### PR DESCRIPTION
Filterer bort stillinger med kilde EURES, slik at stillinger som kommer fra EU ikke sendes tilbake til EU