### PR TITLE
Flytt DB-kredentialer ut av JDBC-URL

### DIFF
--- a/src/main/resources/application-dev-gcp.yml
+++ b/src/main/resources/application-dev-gcp.yml
@@ -1,4 +1,6 @@
 dbnavn: ${DB_DATABASE}
 spring:
   datasource:
-    url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_DATABASE}?user=${DB_USERNAME}&password=${DB_PASSWORD}
+    url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_DATABASE}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}

--- a/src/main/resources/application-prod-gcp.yml
+++ b/src/main/resources/application-prod-gcp.yml
@@ -1,4 +1,6 @@
 dbnavn: ${DB_DATABASE}
 spring:
   datasource:
-    url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_DATABASE}?user=${DB_USERNAME}&password=${DB_PASSWORD}
+    url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_DATABASE}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}


### PR DESCRIPTION
Bruker `spring.datasource.username`/`password` i stedet for å legge brukernavn og passord i JDBC-URL-en. Dette hindrer at DB-kredentialer utilsiktet logges ved fremtidige Spring Boot-oppgraderinger.